### PR TITLE
fix: Update footer copyright year to be dynamic

### DIFF
--- a/src/_includes/layout.njk
+++ b/src/_includes/layout.njk
@@ -26,7 +26,7 @@
     </article>
   </main>
   <footer class="footer">
-    <a href="https://jonathanhudak.com">Jonathan Hudak © 2023</a>
+    <a href="https://jonathanhudak.com">Jonathan Hudak © {{ 'now' | date: '%Y' }}</a>
     <a href="https://github.com/jonathanhudak">Github</a>
     <a href="https://twitter.com/hudak_jonathan">Twitter</a>
     <a href="https://www.linkedin.com/in/jonathan-hudak-084a529/">LinkedIn</a>


### PR DESCRIPTION
Updated copyright year from hardcoded 2023 to dynamic year using Nunjucks templating. This ensures the year auto-updates without manual intervention.

Fixes #6